### PR TITLE
Serve React build via Flask blueprint

### DIFF
--- a/app/views/main.py
+++ b/app/views/main.py
@@ -1,7 +1,19 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, send_from_directory
+import os
 
-views_bp = Blueprint('views', __name__)
+# Define o caminho absoluto da pasta 'build'
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../build'))
 
-@views_bp.route('/')
-def index():
-    return render_template('index.html')
+# Cria o blueprint com a pasta estática correta
+views_bp = Blueprint('views', __name__, static_folder=root_dir)
+
+# Rota principal e fallback para SPA
+@views_bp.route('/', defaults={'path': ''})
+@views_bp.route('/<path:path>')
+def serve(path):
+    file_path = os.path.join(root_dir, path)
+
+    if path != "" and os.path.exists(file_path):
+        return send_from_directory(root_dir, path)
+    else:
+        return send_from_directory(root_dir, 'index.html')


### PR DESCRIPTION
## Summary
- fix blueprint path to correctly serve React build

## Testing
- `python3 -m py_compile app/views/main.py`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840fbc30d5c832ba264bcdb071ff717